### PR TITLE
Fix prices

### DIFF
--- a/pages/api/stripe/create-checkout-session.js
+++ b/pages/api/stripe/create-checkout-session.js
@@ -38,7 +38,7 @@ export default async (req, res) => {
           name,
           images: images.map((img) => img.url)
         },
-        unit_amount: price
+        unit_amount: price * 100
       }
     }
 

--- a/pages/api/stripe/create-checkout-session.js
+++ b/pages/api/stripe/create-checkout-session.js
@@ -26,8 +26,8 @@ export default async (req, res) => {
           id,
           locale
         }
-      )
-
+        )
+      
       return {
         currency,
         product_data: {
@@ -38,7 +38,8 @@ export default async (req, res) => {
           name,
           images: images.map((img) => img.url)
         },
-        unit_amount: price
+        // stripe prices are in smallest currency units - cents, converting to euros:
+        unit_amount: price * 100
       }
     }
 

--- a/pages/api/stripe/create-checkout-session.js
+++ b/pages/api/stripe/create-checkout-session.js
@@ -26,8 +26,8 @@ export default async (req, res) => {
           id,
           locale
         }
-        )
-      
+      )
+
       return {
         currency,
         product_data: {
@@ -38,8 +38,7 @@ export default async (req, res) => {
           name,
           images: images.map((img) => img.url)
         },
-        // stripe prices are in smallest currency units - cents, converting to euros:
-        unit_amount: price * 100
+        unit_amount: price
       }
     }
 

--- a/pages/api/stripe/create-checkout-session.js
+++ b/pages/api/stripe/create-checkout-session.js
@@ -1,5 +1,6 @@
 import hygraphClient, { gql } from '@/lib/hygraph-client'
 import stripe from '@/lib/stripe-client'
+import { convertPrice, convertPriceFormat } from '@/utils/convert-price-format'
 
 export default async (req, res) => {
   try {
@@ -38,7 +39,7 @@ export default async (req, res) => {
           name,
           images: images.map((img) => img.url)
         },
-        unit_amount: price * 100
+        unit_amount: convertPriceFormat('cmsToStripe', price)
       }
     }
 

--- a/pages/success.js
+++ b/pages/success.js
@@ -5,6 +5,7 @@ import getOrderBySessionId from '@/lib/get-order-session-id'
 import { useSettingsContext } from '@/context/settings'
 import Link from 'next/link'
 import { formatCurrencyValue } from '@/utils/format-currency-value'
+import { convertPriceFormat } from '@/utils/convert-price-format'
 
 function SuccessPage() {
   const router = useRouter()
@@ -38,7 +39,7 @@ function SuccessPage() {
         <span className="pr-7">
           {formatCurrencyValue({
             currency: activeCurrency,
-            value: order.total
+            value: convertPriceFormat('stripeToCms', order.total)
           })}
         </span>
       </div>
@@ -70,7 +71,7 @@ function SuccessPage() {
                   Total:{' '}
                   {formatCurrencyValue({
                     currency: activeCurrency,
-                    value: item.total
+                    value: convertPriceFormat('stripeToCms', item.total)
                   })}
                 </p>
                 <p className="font-medium text-gray-800">

--- a/utils/convert-price-format.js
+++ b/utils/convert-price-format.js
@@ -1,0 +1,8 @@
+export const convertPriceFormat = (side, price) => {
+  if (side === 'cmsToStripe') {
+    return price * 100
+  }
+  if (side === 'stripeToCms') {
+    return price / 100
+  }
+}

--- a/utils/format-currency-value.js
+++ b/utils/format-currency-value.js
@@ -2,4 +2,5 @@ export const formatCurrencyValue = ({ currency, value }) =>
   new Intl.NumberFormat('en-US', {
     style: 'currency',
     currency: currency.code
-  }).format(value / 100)
+    //prices are in euros in cms and in cents in stripe, converting to euros:
+  }).format(value)

--- a/utils/format-currency-value.js
+++ b/utils/format-currency-value.js
@@ -2,5 +2,5 @@ export const formatCurrencyValue = ({ currency, value }) =>
   new Intl.NumberFormat('en-US', {
     style: 'currency',
     currency: currency.code
-    //prices are in euros in cms and in cents in stripe, converting to euros:
+    //prices are in euros in cms and in cents in stripe, removed value conversion to cents:
   }).format(value)


### PR DESCRIPTION
Stripe converts prices to minimal units - cents, converted them back to euros to match CMS price format

Closes #3 