### PR TITLE
Tax collection

### DIFF
--- a/pages/api/stripe/create-checkout-session.ts
+++ b/pages/api/stripe/create-checkout-session.ts
@@ -17,47 +17,16 @@ const handler = async (req: NextApiRequest, res: NextApiResponse) => {
     const { items, success_url, cancel_url, cartTotal }: CheckoutSessionBody =
       req.body
 
-    // const getProduct = async (id: string) => {
-    //   const {
-    //     product: { description, images, name, price, ...product }
-    //   } = await hygraphClient.request(
-    //     gql`
-    //       query ProductQuery($id: ID!) {
-    //         product(where: { id: $id }) {
-    //           productId: id
-    //           description
-    //           images(first: 1) {
-    //             url
-    //           }
-    //           name
-    //           price
-    //         }
-    //       }
-    //     `,
-    //     {
-    //       id
-    //     }
-    //   )
-    //   return {
-    //     currency: CURRENCY,
-    //     product_data: {
-    //       description,
-    //       metadata: {
-    //         ...product
-    //       },
-    //       name,
-    //       images: images.map((img: Image) => img.url)
-    //     },
-    //     unit_amount: convertPriceFormat('cmsToStripe', price)
-    //   }
-    // }
-    console.log('items', items)
     const line_items = items.map((item) => ({
       price_data: {
         currency: CURRENCY,
         product_data: {
           name: item.name,
-          images: [item.image.url]
+          images: [item.image.url],
+          tax_code: 'txcd_99999999',
+          metadata: {
+            productId: item.id
+          }
         },
         unit_amount: convertPriceFormat('cmsToStripe', item.price)
       },

--- a/pages/api/stripe/create-checkout-session.ts
+++ b/pages/api/stripe/create-checkout-session.ts
@@ -4,6 +4,7 @@ import { convertPriceFormat } from '@/utils/convert-price-format'
 import { getShippingOptions } from '@/utils/getShippingOptions'
 import type { NextApiRequest, NextApiResponse } from 'next'
 import { Item } from 'react-use-cart'
+import Stripe from 'stripe'
 
 interface CheckoutSessionBody {
   items: Item[]
@@ -23,12 +24,13 @@ const handler = async (req: NextApiRequest, res: NextApiResponse) => {
         product_data: {
           name: item.name,
           images: [item.image.url],
-          tax_code: 'txcd_99999999',
           metadata: {
             productId: item.id
           }
         },
-        unit_amount: convertPriceFormat('cmsToStripe', item.price)
+        unit_amount: convertPriceFormat('cmsToStripe', item.price),
+        tax_behavior:
+          'exclusive' as Stripe.Checkout.SessionCreateParams.LineItem.PriceData.TaxBehavior
       },
       quantity: 1
     }))
@@ -43,7 +45,10 @@ const handler = async (req: NextApiRequest, res: NextApiResponse) => {
         // prettier-ignore
         allowed_countries: [ "AF", "AX", "AL", "DZ", "AD", "AO", "AI", "AQ", "AG", "AR", "AM", "AW", "AU", "AT", "AZ", "BS", "BH", "BD", "BB", "BY", "BE", "BZ", "BJ", "BM", "BT", "BO", "BQ", "BA", "BW", "BV", "BR", "IO", "BN", "BG", "BF", "BI", "KH", "CM", "CA", "CV", "KY", "CF", "TD", "CL", "CN", "CO", "KM", "CG", "CD", "CK", "CR", "CI", "HR", "CW", "CY", "CZ", "DK", "DJ", "DM", "DO", "EC", "EG", "SV", "GQ", "ER", "EE", "ET", "FK", "FO", "FJ", "FI", "FR", "GF", "PF", "TF", "GA", "GM", "GE", "DE", "GH", "GI", "GR", "GL", "GD", "GP", "GU", "GT", "GG", "GN", "GW", "GY", "HT", "VA", "HN", "HK", "HU", "IS", "IN", "ID", "IQ", "IE", "IM", "IL", "IT", "JM", "JP", "JE", "JO", "KZ", "KE", "KI", "KR", "KW", "KG", "LA", "LV", "LB", "LS", "LR", "LY", "LI", "LT", "LU", "MO", "MK", "MG", "MW", "MY", "MV", "ML", "MT", "MQ", "MR", "MU", "YT", "MX", "MD", "MC", "MN", "ME", "MS", "MA", "MZ", "MM", "NA", "NR", "NP", "NL", "NC", "NZ", "NI", "NE", "NG", "NU", "NO", "OM", "PK", "PS", "PA", "PG", "PY", "PE", "PH", "PN", "PL", "PT", "PR", "QA", "RE", "RO", "RU", "RW", "BL", "SH", "KN", "LC", "MF", "PM", "VC", "WS", "SM", "ST", "SA", "SN", "RS", "SC", "SL", "SG", "SX", "SK", "SI", "SB", "SO", "ZA", "GS", "SS", "ES", "LK", "SR", "SJ", "SZ", "SE", "CH", "TW", "TJ", "TZ", "TH", "TL", "TG", "TK", "TO", "TT", "TN", "TR", "TM", "TC", "TV", "UG", "UA", "AE", "GB", "US", "UY", "UZ", "VU", "VE", "VN", "VG", "WF", "EH", "YE", "ZM", "ZW" ]
       },
-      shipping_options: getShippingOptions(cartTotal, items.length)
+      shipping_options: getShippingOptions(cartTotal, items.length),
+      automatic_tax: {
+        enabled: true
+      }
     })
 
     res.status(201).json({ session })

--- a/pages/cart.tsx
+++ b/pages/cart.tsx
@@ -57,10 +57,11 @@ const Cart: React.FC = () => {
 
       const { session } = await res.json()
 
+      setSubmissionSuccess()
+
       await stripe?.redirectToCheckout({
         sessionId: session.id
       })
-      setSubmissionSuccess()
     } catch (error) {
       setSubmissionError(error)
     }


### PR DESCRIPTION
# Motivation
For customers from Europe, we must collect VAT 23%. 

# Solution
Stripe will manage the VAT collection based on the shipping address:
- added tax registration to the Stripe Dashboard
- added tax collection fields to /create-checkout-session
- removed CMS request on /create-checkout-session, we will use information from the cart instead

![Screenshot 2022-09-21 at 18 41 07](https://user-images.githubusercontent.com/4914235/191573921-53ae90c9-96e1-4372-ab9e-e1a0dde51ad0.png)

Closes #14 


