### PR TITLE
Tables in text pages

### DIFF
--- a/pages/pages/[slug].tsx
+++ b/pages/pages/[slug].tsx
@@ -5,6 +5,7 @@ import { GetStaticPaths, GetStaticProps } from 'next'
 import Image from 'next/future/image'
 import React from 'react'
 import { TextPage } from 'types'
+import textPageStyles from '../../styles/textPage.module.css'
 
 function Page({ textPageData }: { textPageData: TextPage }) {
   return (
@@ -21,7 +22,7 @@ function Page({ textPageData }: { textPageData: TextPage }) {
         )}
         <div className="flex justify-center">
           <div
-            className=" sm:w-auto md:max-w-4xl "
+            className={textPageStyles.body}
             dangerouslySetInnerHTML={{ __html: textPageData.page.content.html }}
           />
         </div>

--- a/styles/textPage.module.css
+++ b/styles/textPage.module.css
@@ -1,0 +1,20 @@
+.body {
+  @apply sm:w-auto md:max-w-4xl;
+}
+
+.body table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.body th {
+  background: #282d4c;
+  color: white;
+  font-weight: bold;
+}
+.body td,
+.body th {
+  padding: 6px;
+  border: 1px solid #ccc;
+  text-align: left;
+}


### PR DESCRIPTION
- styles for `table, th, tr, td` to render tables correctly on text pages