### PR TITLE
Fix Pre-render hit rate limit on Hygraph

### DIFF
--- a/lib/get-product-slug.ts
+++ b/lib/get-product-slug.ts
@@ -1,5 +1,6 @@
 import { ProductFragment } from '@/lib/graphql-fragments'
 import hygraphClient, { gql } from '@/lib/hygraph-client'
+import { avoidRateLimit } from '@/utils/avoidRateLimit'
 import { LibParams, Product } from 'types'
 
 export const getProductsSlugQuery = gql`
@@ -15,6 +16,7 @@ export const getProductsSlugQuery = gql`
 export const getProductBySlug = async ({
   slug
 }: LibParams): Promise<Product> => {
+  avoidRateLimit()
   const {
     products: [product]
   } = await hygraphClient.request(getProductsSlugQuery, {

--- a/lib/get-product-slug.ts
+++ b/lib/get-product-slug.ts
@@ -16,7 +16,7 @@ export const getProductsSlugQuery = gql`
 export const getProductBySlug = async ({
   slug
 }: LibParams): Promise<Product> => {
-  avoidRateLimit()
+  await avoidRateLimit()
   const {
     products: [product]
   } = await hygraphClient.request(getProductsSlugQuery, {

--- a/utils/avoidRateLimit.ts
+++ b/utils/avoidRateLimit.ts
@@ -4,6 +4,6 @@ export async function avoidRateLimit() {
   }
 }
 
-function sleep(ms = 300) {
+function sleep(ms = 1000) {
   return new Promise((res) => setTimeout(res, ms))
 }

--- a/utils/avoidRateLimit.ts
+++ b/utils/avoidRateLimit.ts
@@ -4,6 +4,6 @@ export async function avoidRateLimit() {
   }
 }
 
-function sleep(ms = 100) {
+function sleep(ms = 300) {
   return new Promise((res) => setTimeout(res, ms))
 }

--- a/utils/avoidRateLimit.ts
+++ b/utils/avoidRateLimit.ts
@@ -4,6 +4,6 @@ export async function avoidRateLimit() {
   }
 }
 
-function sleep(ms = 1000) {
+function sleep(ms = 500) {
   return new Promise((res) => setTimeout(res, ms))
 }

--- a/utils/avoidRateLimit.ts
+++ b/utils/avoidRateLimit.ts
@@ -1,0 +1,9 @@
+export async function avoidRateLimit() {
+  if (process.env.NODE_ENV === 'production') {
+    await sleep()
+  }
+}
+
+function sleep(ms = 100) {
+  return new Promise((res) => setTimeout(res, ms))
+}


### PR DESCRIPTION
pre-rendering (static product generation) happens too fast for our free hygraph plan